### PR TITLE
Updates default TS value parsing

### DIFF
--- a/utils/tsdoc.utils.ts
+++ b/utils/tsdoc.utils.ts
@@ -130,11 +130,6 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
 
   /* eslint-disable no-fallthrough */
   switch (type.name) {
-    case 'boolean':
-      if (value === 'true') return true;
-      if (value === 'false') return false;
-      return value;
-
     case 'string':
     case 'text':
       return value?.toString() ?? value;
@@ -143,6 +138,13 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
       return Number(value);
 
     case 'enum': {
+
+      if (type.raw === 'boolean'){
+          if (value === 'true') return true;
+          if (value === 'false') return false;
+          return value;
+      }
+
       const valueString = value?.toString();
       const [enumId, defaultKey] = valueString.split('.');
 

--- a/utils/tsdoc.utils.ts
+++ b/utils/tsdoc.utils.ts
@@ -141,8 +141,7 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
 
       if (type.raw === 'boolean'){
           if (value === 'true') return true;
-          if (value === 'false') return false;
-          return value;
+          return false;
       }
 
       const valueString = value?.toString();

--- a/utils/tsdoc.utils.ts
+++ b/utils/tsdoc.utils.ts
@@ -138,10 +138,9 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
       return Number(value);
 
     case 'enum': {
-
-      if (type.raw === 'boolean'){
-          if (value === 'true') return true;
-          return false;
+      if (type.raw === 'boolean') {
+        if (value === 'true') return true;
+        return false;
       }
 
       const valueString = value?.toString();


### PR DESCRIPTION
TSDoc labels `boolean` types as `{name: 'enum', raw: 'boolean'}`. This PR updates our parsing script to handle this.

Now LiveExamples should render with the correct default boolean values (like `darkMode`)