### PR TITLE
LG-2738 navigation fixes

### DIFF
--- a/components/navigation/NavigationContent.tsx
+++ b/components/navigation/NavigationContent.tsx
@@ -98,11 +98,7 @@ function NavigationContent({
                 <SideNavItem
                   key={componentKebabCaseName}
                   onClick={() =>
-                    router.push(
-                      `/component/${componentKebabCaseName}/${
-                        activeTab ? activeTab : 'example'
-                      }`,
-                    )
+                    router.push(`/component/${componentKebabCaseName}/example`)
                   }
                   active={componentKebabCaseName === activePage}
                 >

--- a/components/navigation/NavigationContent.tsx
+++ b/components/navigation/NavigationContent.tsx
@@ -22,7 +22,6 @@ function NavigationContent({
 }) {
   const router = useRouter();
   const activePage = router.asPath.split('/')[2];
-  const activeTab = router.asPath.split('/')[3];
   const { components, contentPageGroups } = useAppContext();
 
   if (!components || !contentPageGroups) {

--- a/components/navigation/NavigationContent.tsx
+++ b/components/navigation/NavigationContent.tsx
@@ -67,7 +67,7 @@ function NavigationContent({
         <>
           {contentPageGroups.map(contentPageGroup => (
             <SideNavGroup
-              key={contentPageGroup.id}
+              key={contentPageGroup.uid}
               header={contentPageGroup.title}
               glyph={<Icon glyph={contentPageGroup.iconname} />}
             >

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,7 +1,15 @@
 import { createContext, useContext } from 'react';
+import { ComponentFields, ContentPageGroup } from 'utils/types';
 
 // TODO: TS type
-const AppContext = createContext<any>({});
+interface AppContextValue {
+  components: Array<ComponentFields>;
+  contentPageGroups: Array<ContentPageGroup>;
+}
+const AppContext = createContext<AppContextValue>({
+  components: [],
+  contentPageGroups: [],
+});
 
 export function AppContextProvider({
   components,

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext } from 'react';
 import { ComponentFields, ContentPageGroup } from 'utils/types';
 
-// TODO: TS type
 interface AppContextValue {
   components: Array<ComponentFields>;
   contentPageGroups: Array<ContentPageGroup>;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ import {
 } from 'utils/getContentstackResources';
 import getFullPageTitle from 'utils/getFullPageTitle';
 import * as ga from 'utils/googleAnalytics';
+import { ContentPageGroup } from 'utils/types';
 
 export type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -21,7 +22,7 @@ export type NextPageWithLayout = NextPage & {
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
   components: any;
-  contentPageGroups: any;
+  contentPageGroups: Array<ContentPageGroup>;
 };
 
 function MyApp({

--- a/utils/getContentstackResources.ts
+++ b/utils/getContentstackResources.ts
@@ -10,10 +10,9 @@ const Stack = Contentstack.Stack({
 
 export async function getComponents(): Promise<Array<ComponentFields>> {
   try {
-    const results: Array<ComponentFields> = (await Stack.ContentType('component')
-      .Query()
-      .toJSON()
-      .find())[0]
+    const results: Array<ComponentFields> = (
+      await Stack.ContentType('component').Query().toJSON().find()
+    )[0];
     return results.sort((a, b) => a.title.localeCompare(b.title));
   } catch (error) {
     console.error('No Component pages found', error);
@@ -22,7 +21,9 @@ export async function getComponents(): Promise<Array<ComponentFields>> {
   }
 }
 
-export async function getComponent(componentName: string): Promise<ComponentFields | undefined> {
+export async function getComponent(
+  componentName: string,
+): Promise<ComponentFields | undefined> {
   try {
     const query = Stack.ContentType('component').Query();
     const result = await query
@@ -39,14 +40,13 @@ export async function getComponent(componentName: string): Promise<ComponentFiel
 export async function getContentPageGroups(): Promise<Array<ContentPageGroup>> {
   try {
     const query = Stack.ContentType('content_page_group').Query();
-    const pageGroups: Array<ContentPageGroup> = (await query
-      .includeReference('content_pages')
-      .toJSON()
-      .find())[0];
+    const pageGroups: Array<ContentPageGroup> = (
+      await query.includeReference('content_pages').toJSON().find()
+    )[0];
     pageGroups.forEach(pageGroup => {
       pageGroup.content_pages.sort((a, b) => a.title.localeCompare(b.title));
-    })
-    return pageGroups
+    });
+    return pageGroups;
   } catch (error) {
     console.error('No Content Page Groups found', error);
     // Return no component pages
@@ -54,7 +54,9 @@ export async function getContentPageGroups(): Promise<Array<ContentPageGroup>> {
   }
 }
 
-export async function getContentPage(contentPageName: string): Promise<ContentPage | undefined> {
+export async function getContentPage(
+  contentPageName: string,
+): Promise<ContentPage | undefined> {
   try {
     const query = Stack.ContentType('content_page').Query();
     const result = await query

--- a/utils/getContentstackResources.ts
+++ b/utils/getContentstackResources.ts
@@ -1,5 +1,6 @@
 import Contentstack from 'contentstack';
 import startCase from 'lodash/startCase';
+import { ComponentFields, ContentPage, ContentPageGroup } from './types';
 
 const Stack = Contentstack.Stack({
   api_key: process.env.NEXT_PUBLIC_CONTENTSTACK_API_KEY as string,
@@ -7,13 +8,13 @@ const Stack = Contentstack.Stack({
   environment: 'main',
 });
 
-export async function getComponents(): Promise<any> {
+export async function getComponents(): Promise<Array<ComponentFields>> {
   try {
-    const results = await Stack.ContentType('component')
+    const results: Array<ComponentFields> = (await Stack.ContentType('component')
       .Query()
       .toJSON()
-      .find();
-    return results[0].sort((a, b) => a.title.localeCompare(b.title));
+      .find())[0]
+    return results.sort((a, b) => a.title.localeCompare(b.title));
   } catch (error) {
     console.error('No Component pages found', error);
     // Return no component pages
@@ -21,7 +22,7 @@ export async function getComponents(): Promise<any> {
   }
 }
 
-export async function getComponent(componentName: string): Promise<any> {
+export async function getComponent(componentName: string): Promise<ComponentFields | undefined> {
   try {
     const query = Stack.ContentType('component').Query();
     const result = await query
@@ -35,14 +36,17 @@ export async function getComponent(componentName: string): Promise<any> {
   }
 }
 
-export async function getContentPageGroups(): Promise<any> {
+export async function getContentPageGroups(): Promise<Array<ContentPageGroup>> {
   try {
     const query = Stack.ContentType('content_page_group').Query();
-    const pageGroups = await query
+    const pageGroups: Array<ContentPageGroup> = (await query
       .includeReference('content_pages')
       .toJSON()
-      .find();
-    return pageGroups[0];
+      .find())[0];
+    pageGroups.forEach(pageGroup => {
+      pageGroup.content_pages.sort((a, b) => a.title.localeCompare(b.title));
+    })
+    return pageGroups
   } catch (error) {
     console.error('No Content Page Groups found', error);
     // Return no component pages
@@ -50,7 +54,7 @@ export async function getContentPageGroups(): Promise<any> {
   }
 }
 
-export async function getContentPage(contentPageName: string) {
+export async function getContentPage(contentPageName: string): Promise<ContentPage | undefined> {
   try {
     const query = Stack.ContentType('content_page').Query();
     const result = await query

--- a/utils/getStaticComponent.ts
+++ b/utils/getStaticComponent.ts
@@ -6,7 +6,7 @@ export async function getStaticComponentPaths() {
 
   const paths = components.map(component => ({
     params: {
-      id: component.id,
+      id: component.uid,
       componentName: kebabCase(component.title),
     },
   }));

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,15 +1,19 @@
 import { CustomComponentDoc } from './tsdoc.utils';
 
-export interface ContentPageFields {
+export interface ContentPageGroup extends Object {
+  uid: string;
   title: string;
+  url: string;
+  iconname: string;
+  content_pages: Array<ContentPage>;
+}
+
+export interface ContentPage {
+  title: string;
+  url: string;
   content: unknown;
 }
 
-export interface ContentPageGroupFields {
-  title: string;
-  iconName: string;
-  contentPages: Array<unknown>;
-}
 export interface ComponentFields {
   title: string;
   description: string;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -15,8 +15,10 @@ export interface ContentPage {
 }
 
 export interface ComponentFields {
+  uid: string;
   title: string;
   description: string;
+  url: string;
   figmaUrl?: string;
   designguidelines?: unknown;
 }


### PR DESCRIPTION
- Default to `example` tab when selecting a component from side nav
- Sort Foundations content pages