### PR TITLE
LG-3120: Support for two-column example card block component

### DIFF
--- a/components/ContentstackRichText/ContentstackEntry.tsx
+++ b/components/ContentstackRichText/ContentstackEntry.tsx
@@ -14,9 +14,9 @@ import AnnotatedImageBlock from './AnnotatedImageBlock';
 import BasicUsageBlock from './BasicUsageBlock';
 import ExampleCardBlock from './ExampleCardBlock';
 import HorizontalLayout from './HorizontalLayout';
+import TwoColumnExampleCard from './TwoColumnExampleCard';
 import { BlockPropsMap, ContentTypeUID } from './types';
 import ContentstackRichText from '.';
-import TwoColumnExampleCard from './TwoColumnExampleCard';
 
 /**
  * An object that maps keys of each `contentTypeUid`

--- a/components/ContentstackRichText/ContentstackEntry.tsx
+++ b/components/ContentstackRichText/ContentstackEntry.tsx
@@ -16,6 +16,7 @@ import ExampleCardBlock from './ExampleCardBlock';
 import HorizontalLayout from './HorizontalLayout';
 import { BlockPropsMap, ContentTypeUID } from './types';
 import ContentstackRichText from '.';
+import TwoColumnExampleCard from './TwoColumnExampleCard';
 
 /**
  * An object that maps keys of each `contentTypeUid`
@@ -70,6 +71,7 @@ const blockToElementMap: {
     </Card>
   ),
   example_card_block: props => <ExampleCardBlock entry={props} />,
+  example_card_block_2_column_: props => <TwoColumnExampleCard entry={props} />,
   expandable_card_block: props => (
     <ExpandableCard
       title={props.title}

--- a/components/ContentstackRichText/TwoColumnExampleCard.tsx
+++ b/components/ContentstackRichText/TwoColumnExampleCard.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+
+import ExampleCardBlock from './ExampleCardBlock';
+import { TwoColumnExampleCardBlockProps } from './types';
+
+const FlexContainer = styled('div')`
+  display: flex;
+  gap: 32px;
+  align-items: stretch;
+`;
+
+const FlexColumn = styled('div')`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: start;
+  justify-content: flex-start;
+  max-width: 100%;
+`;
+
+
+const TwoColumnExampleCard = ({
+  entry
+}: { entry: TwoColumnExampleCardBlockProps}) => {
+  return (
+    <FlexContainer>
+      <FlexColumn>
+        <ExampleCardBlock entry={{
+          title: entry.title,
+          subtext: entry.column_1_subtext,
+          variant: entry.column_1_variant,
+          image: entry.column_1_image
+        }}/>
+      </FlexColumn>
+      <FlexColumn>
+        <ExampleCardBlock entry={{
+          title: entry.title,
+          subtext: entry.column_2_subtext,
+          variant: entry.column_2_variant,
+          image: entry.column_2_image
+        }}/>
+      </FlexColumn>
+    </FlexContainer>
+  )
+}
+
+export default TwoColumnExampleCard;

--- a/components/ContentstackRichText/TwoColumnExampleCard.tsx
+++ b/components/ContentstackRichText/TwoColumnExampleCard.tsx
@@ -18,30 +18,35 @@ const FlexColumn = styled('div')`
   max-width: 100%;
 `;
 
-
 const TwoColumnExampleCard = ({
-  entry
-}: { entry: TwoColumnExampleCardBlockProps}) => {
+  entry,
+}: {
+  entry: TwoColumnExampleCardBlockProps;
+}) => {
   return (
     <FlexContainer>
       <FlexColumn>
-        <ExampleCardBlock entry={{
-          title: entry.title,
-          subtext: entry.column_1_subtext,
-          variant: entry.column_1_variant,
-          image: entry.column_1_image
-        }}/>
+        <ExampleCardBlock
+          entry={{
+            title: entry.title,
+            subtext: entry.column_1_subtext,
+            variant: entry.column_1_variant,
+            image: entry.column_1_image,
+          }}
+        />
       </FlexColumn>
       <FlexColumn>
-        <ExampleCardBlock entry={{
-          title: entry.title,
-          subtext: entry.column_2_subtext,
-          variant: entry.column_2_variant,
-          image: entry.column_2_image
-        }}/>
+        <ExampleCardBlock
+          entry={{
+            title: entry.title,
+            subtext: entry.column_2_subtext,
+            variant: entry.column_2_variant,
+            image: entry.column_2_image,
+          }}
+        />
       </FlexColumn>
     </FlexContainer>
-  )
-}
+  );
+};
 
 export default TwoColumnExampleCard;

--- a/components/ContentstackRichText/types.ts
+++ b/components/ContentstackRichText/types.ts
@@ -137,6 +137,16 @@ export interface HorizontalLayoutBlockProps {
   flex_ratio: `${number}:${number}`;
 }
 
+export interface TwoColumnExampleCardBlockProps {
+  title: string;
+  column_1_subtext: string;
+  column_1_variant: 'info' | 'caution' | 'do' | 'dont';
+  column_1_image: CSImage;
+  column_2_subtext: string;
+  column_2_variant: 'info' | 'caution' | 'do' | 'dont';
+  column_2_image: CSImage;
+}
+
 export interface BlockPropsMap {
   annotated_image_block: AnnotatedImageBlockProps;
   badge_block: BadgeBlockProps;
@@ -147,6 +157,7 @@ export interface BlockPropsMap {
   example_card_block: ExampleCardBlockProps;
   expandable_card_block: ExpandableCardBlockProps;
   horizontal_layout: HorizontalLayoutBlockProps;
+  example_card_block_2_column_: TwoColumnExampleCardBlockProps;
 }
 
 export type ContentTypeUID = keyof BlockPropsMap;


### PR DESCRIPTION
Top instance is the existing `Horizontal Layout > Horizontal Layout Column > Example Card` structure. The bottom instance is the new two-column example card block component.

![image](https://user-images.githubusercontent.com/17347644/234398359-1d8e50b3-c4fa-40d5-8dee-029a01bec35c.png)
