### PR TITLE
LG-3035: parsing TSDoc @links

### DIFF
--- a/components/pages/documentation/TSDocPropTable/TSDocPropTable.tsx
+++ b/components/pages/documentation/TSDocPropTable/TSDocPropTable.tsx
@@ -3,6 +3,7 @@ import {
   getComponentPropsArray,
   getDefaultValueString,
   getInheritedProps,
+  getReplacedTSLink,
   getTypeString,
   isRequired,
 } from 'utils/tsdoc.utils';
@@ -112,7 +113,7 @@ export const TSDocPropTable = ({
                   )}
                 </Cell>
                 <Cell className={cellStyles}>
-                  <Markdown>{propItem.description}</Markdown>
+                  <Markdown>{getReplacedTSLink(propItem.description)}</Markdown>
                 </Cell>
                 <Cell className={cellStyles}>
                   <InlineCode className={typeCellStyle}>

--- a/utils/tsdoc.utils.ts
+++ b/utils/tsdoc.utils.ts
@@ -179,3 +179,32 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
       return value;
   }
 }
+
+/**
+ * Replaces `@link` with a MD link if a URL is provided.
+ * Temp solution: If there is no URL provided then the text after `@link` will be returned.
+ */
+export const getReplacedTSLink = (str: string): string => {
+  return str.replace(/\{@link[^}]*\}/g, match => {
+    if (match.includes('http')) {
+      // look for index of name divider
+      const nameIndex = match.indexOf('|');
+      // check if there is a name;
+      const hasName = nameIndex > 0;
+      // extract the link, if there is a name use that as the ending index, else use the length of the match
+      const link = match.substring(
+        7,
+        hasName ? nameIndex - 1 : match.length - 1,
+      );
+      // extract the name if there is a name
+      const name = hasName
+        ? match.substring(nameIndex + 2, match.length - 1)
+        : link;
+      return `[${name}](${link})`; // Return the link HTML with the URL as text
+    }
+
+    // Return the link name with the @link extracted
+    const linkNameMatch = match.match(/\{@link\s+([^}]+)\}/);
+    return linkNameMatch ? linkNameMatch[1] : '';
+  });
+};

--- a/utils/tsdoc.utils.ts
+++ b/utils/tsdoc.utils.ts
@@ -181,7 +181,7 @@ export function getDefaultValueValue({ defaultValue, type }: PropItem): any {
 }
 
 /**
- * Replaces `@link` with a MD link if a URL is provided.
+ * Replaces external `@link` with a MD link if a URL is provided.
  * Temp solution: If there is no URL provided then the text after `@link` will be returned.
  */
 export const getReplacedTSLink = (str: string): string => {


### PR DESCRIPTION
This will require some updates to the TSDocs on the main repo. https://github.com/mongodb/leafygreen-ui/pull/1738

<img width="800" alt="Screenshot 2023-05-11 at 12 57 48 PM" src="https://github.com/mongodb/design/assets/5740159/b0e15ff4-38fb-41a5-837b-6ace25d1e76c">

<img width="759" alt="Screenshot 2023-05-11 at 5 36 51 PM" src="https://github.com/mongodb/design/assets/5740159/00a81222-e9bc-4462-9802-997a33c501de">

