### PR TITLE
Fixes knob accessible names

### DIFF
--- a/components/pages/example/KnobsTable/Knob/Knob.tsx
+++ b/components/pages/example/KnobsTable/Knob/Knob.tsx
@@ -92,6 +92,7 @@ export const Knob = ({
             value={value}
             onChange={onChange}
             className={cx(inputStyle, rest.className)}
+            role="combobox"
           >
             {knobOptions.map((opt: string) => (
               <Option key={opt} value={opt}>

--- a/components/pages/example/KnobsTable/KnobRow.tsx
+++ b/components/pages/example/KnobsTable/KnobRow.tsx
@@ -49,6 +49,7 @@ interface KnobRowProps extends HTMLElementProps<'div'> {
 export const KnobRow = ({ knob, knobValue, setKnobValue }: KnobRowProps) => {
   const { controlType, name, options, args } = knob;
   const { darkMode } = useDarkMode();
+  const knobLabel = kebabCase(`knob-${name}`);
 
   const renderedKnob = (
     <Knob
@@ -61,7 +62,7 @@ export const KnobRow = ({ knob, knobValue, setKnobValue }: KnobRowProps) => {
         setKnobValue(name, value);
       }}
       className={knobControlStyle}
-      aria-labelledby={`knob-${name}`}
+      aria-labelledby={knobLabel}
       {...args}
     />
   );
@@ -72,7 +73,7 @@ export const KnobRow = ({ knob, knobValue, setKnobValue }: KnobRowProps) => {
         <Body
           baseFontSize={16}
           darkMode={darkMode}
-          id={`${kebabCase()}-knob-${name}`}
+          id={knobLabel}
         >
           <strong>{name}</strong>
           {isRequired(knob) && (


### PR DESCRIPTION
The `aria-labelledby` attribute that's responsible for labeling knob controls doesn't currently match the `id` that's set on said label.

![image](https://github.com/mongodb/design/assets/29065046/88af2e1c-51bd-4ee3-bad3-92fefa170987)

On controls with placeholders (ie, text boxes) this appears to be at least somewhat mitigated by the fact that the placeholder is providing an accessible name to assistive tech. However, for any knob that contains the required disclaimer, that markup still isn't being associated with the input itself.

I did have to make some assumptions about the intended format of the ID based on what was currently there. What I landed on was that they should all be prefixed with the phrase `knob-` and then continue with the kebab-cased version of the knob name.

Additionally, I have added a `role="combobox"` to the knobs that are `<Select>` components. Currently, these controls are communicated by assistive tech as being buttons with a name of whatever the selected value is:
![image](https://github.com/mongodb/design/assets/29065046/e4fb47c4-4c4b-4049-b987-beaaa752c9b7)

 With only the `aria-labelledby` change included in this pull request, the accessible name on these controls would change to match the text of the label (which is good for context) but then would then not communicate the selected value. 
![image](https://github.com/mongodb/design/assets/29065046/512b592b-f943-4f89-8bab-85d1546a9c85)

This change works the other change to put both data points in the accessibility tree.
![image](https://github.com/mongodb/design/assets/29065046/e3ed0166-3e9f-457b-a65f-b18036019d82)

That being said, the combobox change should _probably_ be made at the actual component level. This is intended as band-aid while a library level change like that is considered.